### PR TITLE
Modify DateTimeCaster

### DIFF
--- a/src/TypeCaster/DateTimeCaster.php
+++ b/src/TypeCaster/DateTimeCaster.php
@@ -13,8 +13,10 @@ class DateTimeCaster implements TypeCasterInterface
 
     public function supports(string $type): bool
     {
-        $type = str_replace('\\', '', $type);
+        if (!class_exists($type)) {
+            return false;
+        }
 
-        return \DateTime::class === $type || \DateTimeImmutable::class === $type;
+        return (new \ReflectionClass($type))->implementsInterface(\DateTimeInterface::class);
     }
 }


### PR DESCRIPTION
support for Carbon

```
class Carbon extends DateTime implements CarbonInterface
{
}

class CarbonImmutable extends DateTimeImmutable implements CarbonInterface
{
}

↓

interface CarbonInterface extends DateTimeInterface, JsonSerializable
{
}
```

\DateTimeも Carbonも \DateTimeInterfaceをimplementsしているので、どちらでも使えるようになるかと思います 🙇 